### PR TITLE
Corrige referencia ao favicon

### DIFF
--- a/sistema_rateio/sistema_rateio/urls.py
+++ b/sistema_rateio/sistema_rateio/urls.py
@@ -1,9 +1,12 @@
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
+from django.views.generic import RedirectView
+from django.contrib.staticfiles.storage import staticfiles_storage
 from . import views
 
 urlpatterns = [
+    path('favicon.ico', RedirectView.as_view(url=staticfiles_storage.url('img/favicon.ico'))),
     path('', views.home, name='home'),
     path('admin/', admin.site.urls),
     path('login/', auth_views.LoginView.as_view(), name='login'),

--- a/sistema_rateio/templates/base.html
+++ b/sistema_rateio/templates/base.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% static 'img/favicon.ico' as favicon %}
 <!DOCTYPE html>
 <html lang="pt-br">
 <head>
@@ -11,8 +10,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
       <link rel="stylesheet" href="{% static 'css/style.css' %}">
-      <link rel="icon" type="image/x-icon" href="{{ favicon }}?v=2">
-      <link rel="shortcut icon" type="image/x-icon" href="{{ favicon }}?v=2">
+      <link rel="icon" type="image/x-icon" href="/favicon.ico">
+      <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
   </head>
 <body class="pb-4">
 


### PR DESCRIPTION
## Resumo
- Usa `/favicon.ico` no template base para garantir exibição do ícone

## Testes
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb0a0bc88333ba758c874151f895